### PR TITLE
write file locations as double quote instead of single quote for tslint

### DIFF
--- a/createTypeScriptIndex.ts
+++ b/createTypeScriptIndex.ts
@@ -110,10 +110,10 @@ export async function indexWriter(
       });
 
       if (option.useSemicolon) {
-        return `export * from './${targetFileWithoutExt}';`;
+        return `export * from "./${targetFileWithoutExt}";`;
       }
 
-      return `export * from './${targetFileWithoutExt}'`;
+      return `export * from "./${targetFileWithoutExt}"`;
     });
 
     const comment = (() => {


### PR DESCRIPTION
before, the created index files had lines like: `export * from './Class'`
tslint gives a warning for using single quotes for strings.
now it will write lines like: `export * from "./Class"`