### PR TITLE
BC mode fix

### DIFF
--- a/src/commands/CommandModule.ts
+++ b/src/commands/CommandModule.ts
@@ -45,7 +45,7 @@ export class CommandModule {
         // Step 4, remove exclude pattern
         .filter((filename) => {
           return !option.fileExcludePatterns.reduce<boolean>((result, excludePattern) => {
-            if (/\w+/.test(excludePattern)) {
+            if (!glob.hasMagic(excludePattern, option.globOptions)) {
               // backward compatibility for indexOf
               return result || minimatch(filename, `*${excludePattern}*`);
             }


### PR DESCRIPTION
Fixed BC mode to only work for paths with no magic, and made it properly match a file in any folder.

The previous regex "\w+" would effectively match almost all patterns, except those that are pure magic and no letters. f.e. I used the pattern ```**/*spec.ts```, and that one was caught in BC mode, because of the "spec.ts" part. This means that the effective pattern was ```***/*spec.ts*``` which is invalid because of the 3 ```*```, and thus there were no matches.

With this fix, any pattern that contains magic according to glob will be executed as is, while all non-magic ones will be ran in BC mode.